### PR TITLE
Fix App.vue TypeError: this._init is not a function when running npm run dev

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,11 +16,11 @@ module.exports = {
         loaders: [
             {
                 test: /\.vue$/,
-                loader: 'vue'
+                loader: 'vue-loader'
             },
             {
                 test: /\.(png|jpg|gif|svg)$/,
-                loader: 'file',
+                loader: 'file-loader',
                 query: {
                     name: '[name].[ext]?[hash]'
                 }


### PR DESCRIPTION
Fix the #1 . The loader format is changed in the latest webpack.